### PR TITLE
LUGG-1186 Add red color variant

### DIFF
--- a/css/luggage_bean_stat.css
+++ b/css/luggage_bean_stat.css
@@ -40,3 +40,30 @@ a.stat-card_button.external:after {
   content: '' !important;
   display: none !important;
 }
+
+/* Color variants */
+
+.stat-bean_red.stat-card {
+  color: #333;
+}
+
+.stat-bean_red .stat-card_icon {
+  color: #767676;
+}
+
+.stat-bean_red .stat-card_title {
+  color: #cc0000;
+  xtext-shadow: 3px 3px #cc0000;
+}
+
+.stat-bean_red a.stat-card_button {
+  color: #ffffff;
+  background: #cc0000;
+  border-color: #cc0000;
+}
+
+.stat-bean_red a.stat-card_button:hover, 
+.stat-bean_red a.stat-card_button:focus {
+  background: #333333;
+  border-color: #333333;
+}

--- a/luggage_bean_stat.features.field_base.inc
+++ b/luggage_bean_stat.features.field_base.inc
@@ -58,6 +58,31 @@ function luggage_bean_stat_field_default_field_bases() {
     'type' => 'text_long',
   );
 
+  // Exported field_base: 'field_stat_color_variant'.
+  $field_bases['field_stat_color_variant'] = array(
+    'active' => 1,
+    'cardinality' => 1,
+    'deleted' => 0,
+    'entity_types' => array(),
+    'field_name' => 'field_stat_color_variant',
+    'indexes' => array(
+      'value' => array(
+        0 => 'value',
+      ),
+    ),
+    'locked' => 0,
+    'module' => 'list',
+    'settings' => array(
+      'allowed_values' => array(
+        'stat-bean_white' => 'White',
+        'stat-bean_red' => 'Red',
+      ),
+      'allowed_values_function' => '',
+    ),
+    'translatable' => 0,
+    'type' => 'list_text',
+  );
+
   // Exported field_base: 'field_stat_icon'.
   $field_bases['field_stat_icon'] = array(
     'active' => 1,

--- a/luggage_bean_stat.features.field_instance.inc
+++ b/luggage_bean_stat.features.field_instance.inc
@@ -22,7 +22,7 @@ function luggage_bean_stat_field_default_field_instances() {
         'module' => 'link',
         'settings' => array(),
         'type' => 'link_default',
-        'weight' => 0,
+        'weight' => 1,
       ),
     ),
     'entity_type' => 'bean',
@@ -74,7 +74,7 @@ function luggage_bean_stat_field_default_field_instances() {
         'module' => 'text',
         'settings' => array(),
         'type' => 'text_default',
-        'weight' => 2,
+        'weight' => 3,
       ),
     ),
     'entity_type' => 'bean',
@@ -131,6 +131,42 @@ function luggage_bean_stat_field_default_field_instances() {
     ),
   );
 
+  // Exported field_instance: 'bean-stat-field_stat_color_variant'.
+  $field_instances['bean-stat-field_stat_color_variant'] = array(
+    'bundle' => 'stat',
+    'default_value' => array(
+      0 => array(
+        'value' => 'stat-bean_red',
+      ),
+    ),
+    'deleted' => 0,
+    'description' => 'Choose a color variant to coordinate with the background color. If this card will be on a red or dark background, choose White (which uses mostly white text). If it will be on a white or light background, choose Red (which uses red and black text). <br>
+<br><strong>This shouldn\'t need to be changed unless the page is redesigned or the card is moved. </strong>',
+    'display' => array(
+      'default' => array(
+        'label' => 'above',
+        'module' => 'list',
+        'settings' => array(),
+        'type' => 'list_default',
+        'weight' => 5,
+      ),
+    ),
+    'entity_type' => 'bean',
+    'field_name' => 'field_stat_color_variant',
+    'label' => 'Color Variant',
+    'required' => 1,
+    'settings' => array(
+      'user_register_form' => FALSE,
+    ),
+    'widget' => array(
+      'active' => 1,
+      'module' => 'options',
+      'settings' => array(),
+      'type' => 'options_select',
+      'weight' => 5,
+    ),
+  );
+
   // Exported field_instance: 'bean-stat-field_stat_icon'.
   $field_instances['bean-stat-field_stat_icon'] = array(
     'bundle' => 'stat',
@@ -143,7 +179,7 @@ function luggage_bean_stat_field_default_field_instances() {
         'module' => 'list',
         'settings' => array(),
         'type' => 'list_default',
-        'weight' => 1,
+        'weight' => 2,
       ),
     ),
     'entity_type' => 'bean',
@@ -166,6 +202,9 @@ function luggage_bean_stat_field_default_field_instances() {
   // Included for use with string extractors like potx.
   t('Button');
   t('Caption');
+  t('Choose a color variant to coordinate with the background color. If this card will be on a red or dark background, choose White (which uses mostly white text). If it will be on a white or light background, choose Red (which uses red and black text). <br>
+<br><strong>This shouldn\'t need to be changed unless the page is redesigned or the card is moved. </strong>');
+  t('Color Variant');
   t('Icon');
   t('Show a button at the bottom of the Stat card.');
   t('Supporting text for the large title. Recommended length is no more than 150 characters.');

--- a/luggage_bean_stat.info
+++ b/luggage_bean_stat.info
@@ -1,4 +1,5 @@
 name = luggage_bean_stat
+description = Highlight a fact or statistic with an icon, number, description, and button.
 core = 7.x
 package = Luggage
 version = 7.x-1.0
@@ -17,9 +18,11 @@ features[ctools][] = strongarm:strongarm:1
 features[features_api][] = api:2
 features[field_base][] = field_stat_button
 features[field_base][] = field_stat_caption
+features[field_base][] = field_stat_color_variant
 features[field_base][] = field_stat_icon
 features[field_instance][] = bean-stat-field_stat_button
 features[field_instance][] = bean-stat-field_stat_caption
+features[field_instance][] = bean-stat-field_stat_color_variant
 features[field_instance][] = bean-stat-field_stat_icon
 features[user_permission][] = create any stat bean
 features[user_permission][] = delete any stat bean

--- a/templates/bean--stat.tpl.php
+++ b/templates/bean--stat.tpl.php
@@ -1,4 +1,4 @@
-<div class="stat-card">
+<div class="stat-card <?php if(isset($bean->field_stat_color_variant['und'][0]['value'])): print $bean->field_stat_color_variant['und'][0]['value']; endif; ?>">
   <?php print render($title_suffix) ?>
 
   <?php if (isset($bean->field_stat_icon['und'][0]['value'])): ?>


### PR DESCRIPTION
This adds a dropdown menu to choose a color variant, so the block can be placed on either a light or dark background. Right now, the design is white so only works on red or black backgrounds. Now there is a variant that uses red and black so it works on light background. 

To test:
1. Create a stat bean.
2. Does it default to the red variant?
3. Can you see all the elements clearly on a white background?
4. Edit the stat and change the variant to white.
5. This should revert back to the original colors (white) and would only look right on a dark background.